### PR TITLE
Add cancelSaleCreationRequest method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokend/js-sdk",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokend/js-sdk",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "js-sdk is a client-side SDK for TokenD asset tokenization platform.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/base/operations/sale_request_builder.js
+++ b/src/base/operations/sale_request_builder.js
@@ -135,6 +135,27 @@ export class SaleRequestBuilder {
     return new xdr.Operation(opAttributes)
   }
 
+  /**
+   * Creates operation to cancel sale request
+   * @param {object} opts
+   * @param {string} opts.requestID - ID of the request
+   * @param {string} [opts.source] - The source account for the operation.
+   * Defaults to the transaction's source account.
+   * @returns {xdr.CancelSaleCreationRequestOp}
+   */
+  static cancelSaleCreationRequest (opts) {
+    let cancelSaleCreationRequestOp = new xdr.CancelSaleCreationRequestOp({
+      requestId: UnsignedHyper.fromString(opts.requestID),
+      ext: new xdr.CancelSaleCreationRequestOpExt(
+        xdr.LedgerVersion.emptyVersion())
+    })
+    let opAttributes = {}
+    opAttributes.body = xdr.OperationBody.cancelSaleRequest(
+      cancelSaleCreationRequestOp)
+    BaseOperation.setSourceAccount(opAttributes, opts)
+    return new xdr.Operation(opAttributes)
+  }
+
   static validateDetail (details) {
     if (isUndefined(details)) {
       throw new Error('details is invalid')


### PR DESCRIPTION
The method was copied from [old js-base](https://github.com/tokend/js-base/blob/9bfc133dea57e256545001d1da67fff3bdef14e7/src/operations/sale_request_builder.js#L46-L65). Looks like it was lost after migration to the new SDK.

+ cancelSaleCreationRequest method for canceling sale requests
+ update SDK version 0.3.21 -> 0.3.22